### PR TITLE
Move Laminar Correlation to TBV

### DIFF
--- a/reactionRateModels/turbulentBurningVelocityModels/Bradley/Bradley.C
+++ b/reactionRateModels/turbulentBurningVelocityModels/Bradley/Bradley.C
@@ -52,15 +52,7 @@ Foam::turbulentBurningVelocityModels::Bradley::Bradley
     const dictionary& dict
 ):
     turbulentBurningVelocity(modelType, reactRate, dict),
-    Le_(dict.optionalSubDict(modelType + "Coeffs").lookup<scalar>("Le")),
-    laminarCorrelation_(
-        laminarBurningVelocity::New
-        (
-            combModel_.coeffs(),
-            this->mesh_,
-            combModel_
-        )
-    )
+    Le_(dict.optionalSubDict(modelType + "Coeffs").lookup<scalar>("Le"))
 {
     appendInfo("\tTBV estimation method: Bradley correlation");
     appendInfo("\t\tLe: " + name(Le_));

--- a/reactionRateModels/turbulentBurningVelocityModels/Bradley/Bradley.H
+++ b/reactionRateModels/turbulentBurningVelocityModels/Bradley/Bradley.H
@@ -58,8 +58,6 @@ class Bradley
         //- Molecular Lewis number of fresh mixture
         scalar Le_;
 
-        autoPtr<laminarBurningVelocity> laminarCorrelation_;
-
 public:
 
     //- Runtime type information

--- a/reactionRateModels/turbulentBurningVelocityModels/Bray/Bray.C
+++ b/reactionRateModels/turbulentBurningVelocityModels/Bray/Bray.C
@@ -51,15 +51,7 @@ Foam::turbulentBurningVelocityModels::Bray::Bray
     const reactionRate& reactRate,
     const dictionary& dict
 ):
-    turbulentBurningVelocity(modelType, reactRate, dict),
-    laminarCorrelation_(
-        laminarBurningVelocity::New
-        (
-            combModel_.coeffs(),
-            this->mesh_,
-            combModel_
-        )
-    )
+    turbulentBurningVelocity(modelType, reactRate, dict)
 {
     appendInfo("\tTBV estimation method: Bray correlation");
 }

--- a/reactionRateModels/turbulentBurningVelocityModels/Bray/Bray.H
+++ b/reactionRateModels/turbulentBurningVelocityModels/Bray/Bray.H
@@ -58,8 +58,6 @@ class Bray
         //- Molecular Lewis number of fresh mixture
         scalar Le_;
 
-        autoPtr<laminarBurningVelocity> laminarCorrelation_;
-
 public:
 
     //- Runtime type information

--- a/reactionRateModels/turbulentBurningVelocityModels/Zimont/Zimont.C
+++ b/reactionRateModels/turbulentBurningVelocityModels/Zimont/Zimont.C
@@ -55,15 +55,7 @@ Foam::turbulentBurningVelocityModels::Zimont::Zimont
     ZimontA_(dict.optionalSubDict(modelType + "Coeffs").lookup<scalar>("ZimontA")),
     alpha_u_(dimensionedScalar(dimViscosity, dict.optionalSubDict(modelType + "Coeffs").lookup<scalar>("alpha_u"))),
     Le_(dict.optionalSubDict(modelType + "Coeffs").lookupOrDefault<scalar>("Le", 1.0)),
-    ACalpha_(ZimontA_*Foam::pow(0.37, 0.25)*Foam::pow(alpha_u_, -0.25)*Foam::pow(Le_, -0.3)),
-    laminarCorrelation_(
-        laminarBurningVelocity::New
-        (
-            combModel_.coeffs(),
-            this->mesh_,
-            combModel_
-        )
-    )
+    ACalpha_(ZimontA_*Foam::pow(0.37, 0.25)*Foam::pow(alpha_u_, -0.25)*Foam::pow(Le_, -0.3))
 {
     appendInfo("\tTBV estimation method: Zimont correlation");
 }

--- a/reactionRateModels/turbulentBurningVelocityModels/Zimont/Zimont.H
+++ b/reactionRateModels/turbulentBurningVelocityModels/Zimont/Zimont.H
@@ -64,8 +64,6 @@ class Zimont
 
         const dimensionedScalar ACalpha_;
 
-        autoPtr<laminarBurningVelocity> laminarCorrelation_;
-
 public:
 
     //- Runtime type information

--- a/reactionRateModels/turbulentBurningVelocityModels/turbulentBurningVelocity/turbulentBurningVelocity.C
+++ b/reactionRateModels/turbulentBurningVelocityModels/turbulentBurningVelocity/turbulentBurningVelocity.C
@@ -60,6 +60,14 @@ Foam::turbulentBurningVelocity::turbulentBurningVelocity
         mesh_,
         dimensionedScalar("TBV", dimVelocity, Zero)
     ),
+    laminarCorrelation_(
+        laminarBurningVelocity::New
+        (
+            combModel_.coeffs(),
+            this->mesh_,
+            combModel_
+        )
+    ),
     debug_(dict.lookupOrDefault("debug", false))
 {
     Info << "flameFoam turbulentBurningVelocity object initialized" << endl;
@@ -77,6 +85,11 @@ Foam::turbulentBurningVelocity::~turbulentBurningVelocity()
 Foam::tmp<Foam::volScalarField> Foam::turbulentBurningVelocity::saneEpsilon()
 {
     return max(combModel_.turbulence().epsilon(), dimensionedScalar(dimVelocity*dimAcceleration, SMALL));
+}
+
+const Foam::volScalarField& Foam::turbulentBurningVelocity::getLaminarBurningVelocity()
+{
+    return laminarCorrelation_().burningVelocity();
 }
 
 

--- a/reactionRateModels/turbulentBurningVelocityModels/turbulentBurningVelocity/turbulentBurningVelocity.H
+++ b/reactionRateModels/turbulentBurningVelocityModels/turbulentBurningVelocity/turbulentBurningVelocity.H
@@ -44,6 +44,7 @@ SourceFiles
 #include "fvmSup.H"
 #include "infoPass.H"
 #include "reactionRate.H"
+#include "laminarBurningVelocity.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -76,6 +77,9 @@ protected:
 
         //- Turbulent burning velocity
         volScalarField sTurbulent_;
+
+        //- Laminar corrrelation
+        autoPtr<laminarBurningVelocity> laminarCorrelation_;
 
         bool debug_;
 
@@ -143,6 +147,8 @@ public:
                 return sTurbulent_;
             }
 
+            //- Return laminar burning velocity
+            const volScalarField& getLaminarBurningVelocity();
 
         //- Correct progress variable source
         // virtual void correct() = 0;


### PR DESCRIPTION
Laminar correlation is now instantiated in turbulent burning velocity base class. 
TBV models access laminar correlation through inheritance. 
Accessor function can be used to get laminar burning velocity.