### PR TITLE
Implement ETFC model

### DIFF
--- a/Make/files
+++ b/Make/files
@@ -15,6 +15,7 @@ reactionRateModels/laminarBurningVelocityModels/Malet/Malet.C
 reactionRateModels/reactionRate/reactionRate.C
 reactionRateModels/reactionRate/reactionRateNew.C
 reactionRateModels/TFC/TFC.C
+reactionRateModels/ETFC/ETFC.C
 reactionRateModels/FSD/FSD.C
 flameFoam.C
 

--- a/reactionRateModels/ETFC/ETFC.C
+++ b/reactionRateModels/ETFC/ETFC.C
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2023 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is derivative work of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "ETFC.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace reactionRateModels
+{
+    defineTypeNameAndDebug(ETFC, 0);
+    addToRunTimeSelectionTable
+    (
+        reactionRate,
+        ETFC,
+        dictionary
+    );
+}
+}
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::reactionRateModels::ETFC::ETFC
+(
+    const word modelType,
+    const dictionary& dict,
+    const fvMesh& mesh,
+    const combustionModel& combModel
+)
+:
+    reactionRate(modelType, dict, mesh, combModel),
+    turbulentCorrelation_(
+        turbulentBurningVelocity::New
+        (
+            *this,
+            dict
+        )
+    ),
+    c_(combModel_.thermo().composition().Y("c")),
+    Sct_("Sct", dimless, 0),
+    alpha_u_("alpha_u", dimViscosity, this->coeffDict_),
+    Le_("Le", dimless, this->coeffDict_)
+{
+    IOdictionary thermophysicalTransportDict
+    (
+        IOobject
+        (
+            "thermophysicalTransport",
+            mesh.time().constant(),
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::NO_WRITE
+        )
+    );
+    Sct_ = thermophysicalTransportDict.lookup<scalar>("Sct");
+
+    appendInfo("Reaction rate model: ETFC");
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::reactionRateModels::ETFC::~ETFC()
+{}
+
+
+// * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * * //
+
+void Foam::reactionRateModels::ETFC::correct
+(
+)
+{
+    if (debug_)
+    {
+        Info << "\tETFC correct:" << endl;
+        Info << "\t\tInitial min/avg/max cSource: " << min(cSource_).value() << " " << average(cSource_).value() << " " << max(cSource_).value() << endl;
+    }
+
+    turbulentCorrelation_->correct();
+
+    volScalarField Dt_inf = combModel_.turbulence().nut()/Sct_;
+
+    volScalarField TauByT = max(1.5* Dt_inf/(combModel_.turbulence().k()*mesh_.time()), SMALL);
+
+    volScalarField expFactor = 1 - exp(-1/TauByT);
+
+    volScalarField cLam = 0.25*pow(turbulentCorrelation_->getLaminarBurningVelocity(), 2)*
+        rhoU()*max(c_-SMALL*mesh_.time().deltaT().value(),0.0)*(1-c_)/
+        (alpha_u_/Le_+Dt_inf*expFactor);
+
+    cSource_ =
+        rhoU()*
+        turbulentCorrelation_->burningVelocity()*
+        mag(fvc::grad(c_))*
+        pow((max(1-expFactor*TauByT, 0.0)),0.5)  + cLam;
+
+    if (debug_)
+    {
+        Info << "\t\tObtained min/avg/max cSource: " << min(cSource_).value() << " " << average(cSource_).value() << " " << max(cSource_).value() << endl;
+        Info << "\t\tETFC correct finished" << endl;
+    }
+}
+
+char const *Foam::reactionRateModels::ETFC::getInfo()
+{
+    infoString_.append(turbulentCorrelation_().getInfo());
+    turbulentCorrelation_().clearInfo();
+    return infoString_.c_str();
+}

--- a/reactionRateModels/ETFC/ETFC.H
+++ b/reactionRateModels/ETFC/ETFC.H
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2023 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is derivative work of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::reactionRateModels::ETFC
+
+Description
+    ETFC model for combustion progress variable equation closure
+
+SourceFiles
+    ETFC.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef TFC_H
+#define TFC_H
+
+#include "reactionRate.H"
+#include "turbulentBurningVelocity.H"
+#include "laminarBurningVelocity.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace reactionRateModels
+{
+
+/*---------------------------------------------------------------------------*\
+                         Class ETFC Declaration
+\*---------------------------------------------------------------------------*/
+
+class ETFC
+:
+    public reactionRate
+{
+    // Private Data
+
+        //- Auto pointer to reaction rate model
+        autoPtr<turbulentBurningVelocity> turbulentCorrelation_;
+
+        autoPtr<laminarBurningVelocity> laminarCorrelation_;
+
+	const volScalarField& c_;
+protected:
+
+    // Protected data
+
+        // Model coefficients
+
+            //- Turbulent Schmidt number []
+            dimensionedScalar Sct_;
+
+            dimensionedScalar alpha_u_;
+
+            dimensionedScalar Le_;
+public:
+
+    //- Runtime type information
+    TypeName("ETFC");
+
+
+    // Constructors
+
+        //- Construct from dictionary, mesh and combustion model
+        ETFC
+        (
+            const word modelType,
+            const dictionary& dictCoeffs,
+            const fvMesh& mesh,
+            const combustionModel& combModel
+        );
+
+        //- Disallow default bitwise copy construction
+        ETFC(const ETFC&) = delete;
+
+
+    // Destructor
+
+        virtual ~ETFC();
+
+
+    // Member Functions
+
+        //- Correct combustion source
+        virtual void correct();
+
+    // IO
+
+        //- Update properties from given dictionary
+        // virtual bool read(const dictionary& dictProperties);
+
+        //- Return infoString_
+        virtual char const *getInfo();
+
+
+    // Member Operators
+
+        //- Disallow default bitwise assignment
+        void operator=(const ETFC&) = delete;
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End reactionRateFlameAreaModels
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //


### PR DESCRIPTION
To run the ETFC model calculation, change the reactionRate model to ETFC in combustionProperties dictionary and specify "Le" and "alpha_u" parameters.